### PR TITLE
Add Foundry bridge (Flask) + Foundry module + bridge client (Phase 1 read-only)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ dotenv = "*"
 dnd-app-lib = {file = "lib/", editable = true}
 python-dotenv = "*"
 pyinstaller = "*"
+flask = "*"
 
 [dev-packages]
 pyinstaller = "*"

--- a/bridge_service/__init__.py
+++ b/bridge_service/__init__.py
@@ -1,0 +1,3 @@
+from bridge_service.app import create_app
+
+__all__ = ["create_app"]

--- a/bridge_service/app.py
+++ b/bridge_service/app.py
@@ -1,0 +1,131 @@
+import json
+import os
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from flask import Flask, jsonify, request
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _default_snapshot() -> Dict[str, Any]:
+    return {
+        "source": "foundry",
+        "world": "",
+        "timestamp": _utc_now(),
+        "combat": {
+            "active": False,
+            "id": None,
+            "round": 0,
+            "turn": 0,
+            "activeCombatant": None,
+        },
+        "combatants": [],
+    }
+
+
+@dataclass
+class SnapshotStore:
+    snapshot: Optional[Dict[str, Any]] = None
+    lock: threading.Lock = threading.Lock()
+
+    def get(self) -> Dict[str, Any]:
+        with self.lock:
+            if self.snapshot is None:
+                return _default_snapshot()
+            return self.snapshot
+
+    def set(self, snapshot: Dict[str, Any]) -> None:
+        with self.lock:
+            self.snapshot = snapshot
+
+
+def _load_env(name: str, default: Optional[str] = None) -> str:
+    value = os.getenv(name, "").strip()
+    if value:
+        return value
+    return default or ""
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    store = SnapshotStore()
+
+    def _require_bearer() -> Optional[Any]:
+        token = _load_env("BRIDGE_TOKEN")
+        if not token:
+            return jsonify({"error": "BRIDGE_TOKEN not set"}), 503
+        header = request.headers.get("Authorization", "")
+        if header != f"Bearer {token}":
+            return jsonify({"error": "unauthorized"}), 401
+        return None
+
+    def _require_ingest_secret() -> Optional[Any]:
+        secret = _load_env("BRIDGE_INGEST_SECRET")
+        if not secret:
+            return None
+        header = request.headers.get("X-Bridge-Secret", "")
+        if header != secret:
+            return jsonify({"error": "unauthorized"}), 401
+        return None
+
+    def _persist_snapshot(snapshot: Dict[str, Any]) -> None:
+        path = _load_env("BRIDGE_SNAPSHOT_PATH")
+        if not path:
+            return
+        try:
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump(snapshot, handle, indent=2, sort_keys=True)
+        except Exception as exc:
+            print(f"[Bridge] Failed to persist snapshot: {exc}")
+
+    @app.get("/health")
+    def health() -> Any:
+        auth = _require_bearer()
+        if auth is not None:
+            return auth
+        return jsonify({"status": "ok"})
+
+    @app.get("/state")
+    def state() -> Any:
+        auth = _require_bearer()
+        if auth is not None:
+            return auth
+        return jsonify(store.get())
+
+    @app.get("/version")
+    def version() -> Any:
+        auth = _require_bearer()
+        if auth is not None:
+            return auth
+        return jsonify({"version": _load_env("BRIDGE_VERSION", "dev")})
+
+    @app.post("/foundry/snapshot")
+    def foundry_snapshot() -> Any:
+        auth = _require_ingest_secret()
+        if auth is not None:
+            return auth
+        payload = request.get_json(silent=True)
+        if not payload:
+            return jsonify({"error": "missing payload"}), 400
+        store.set(payload)
+        _persist_snapshot(payload)
+        world = payload.get("world", "")
+        combatants = payload.get("combatants", [])
+        print(
+            f"[Bridge] Snapshot received world={world!r} combatants={len(combatants)}"
+        )
+        return jsonify({"status": "ok"})
+
+    return app
+
+
+if __name__ == "__main__":
+    host = _load_env("BRIDGE_HOST", "127.0.0.1")
+    port = int(_load_env("BRIDGE_PORT", "8787"))
+    app = create_app()
+    app.run(host=host, port=port, threaded=True)

--- a/deploy/bridge.service
+++ b/deploy/bridge.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Foundry Bridge Service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/dnd_app
+EnvironmentFile=-/etc/dnd_app/bridge.env
+ExecStart=/opt/dnd_app/.venv/bin/python -m bridge_service.app
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/foundryvtt-bridge/bridge.js
+++ b/foundryvtt-bridge/bridge.js
@@ -1,0 +1,152 @@
+const MODULE_ID = "foundryvtt-bridge";
+const DEFAULT_BRIDGE_URL = "http://127.0.0.1:8787";
+
+function getBridgeUrl() {
+  const raw = game.settings.get(MODULE_ID, "bridgeUrl") || DEFAULT_BRIDGE_URL;
+  return raw.replace(/\/$/, "");
+}
+
+function getBridgeSecret() {
+  const secret = game.settings.get(MODULE_ID, "bridgeSecret");
+  if (!secret) return "";
+  return String(secret).trim();
+}
+
+function buildCombatSnapshot() {
+  const combat = game.combat ?? null;
+  const world = game.world?.title ?? game.world?.name ?? "";
+  const active = Boolean(
+    combat && (combat.started ?? combat.active ?? combat.round > 0 || combat.turn !== null)
+  );
+
+  const activeCombatant = combat?.combatant
+    ? {
+        tokenId: combat.combatant.token?.id ?? combat.combatant.tokenId ?? null,
+        actorId: combat.combatant.actor?.id ?? null,
+        name: combat.combatant.name ?? combat.combatant.actor?.name ?? "",
+        initiative: combat.combatant.initiative ?? null,
+      }
+    : null;
+
+  const combatants = (combat?.combatants ?? []).map((c) => {
+    const actor = c.actor;
+    const hp = actor?.system?.attributes?.hp ?? {};
+    const effects = (actor?.effects ?? []).map((effect) => ({
+      id: effect.id,
+      label: effect.label ?? effect.name ?? "",
+    }));
+
+    return {
+      tokenId: c.token?.id ?? c.tokenId ?? null,
+      actorId: actor?.id ?? null,
+      name: c.name ?? actor?.name ?? "",
+      initiative: c.initiative ?? null,
+      hp: {
+        value: hp.value ?? null,
+        max: hp.max ?? null,
+      },
+      effects,
+    };
+  });
+
+  return {
+    source: "foundry",
+    world,
+    timestamp: new Date().toISOString(),
+    combat: {
+      active,
+      id: combat?.id ?? null,
+      round: combat?.round ?? 0,
+      turn: combat?.turn ?? 0,
+      activeCombatant,
+    },
+    combatants,
+  };
+}
+
+let snapshotTimer = null;
+
+function scheduleSnapshot(reason) {
+  if (snapshotTimer) {
+    clearTimeout(snapshotTimer);
+  }
+  snapshotTimer = setTimeout(async () => {
+    snapshotTimer = null;
+    await postSnapshot(reason);
+  }, 150);
+}
+
+async function postSnapshot(reason) {
+  const snapshot = buildCombatSnapshot();
+  const bridgeUrl = getBridgeUrl();
+  const endpoint = `${bridgeUrl}/foundry/snapshot`;
+  const secret = getBridgeSecret();
+  const headers = {
+    "Content-Type": "application/json",
+  };
+  if (secret) {
+    headers["X-Bridge-Secret"] = secret;
+  }
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(snapshot),
+    });
+    if (!response.ok) {
+      console.error(
+        `[${MODULE_ID}] Snapshot post failed (${response.status})`,
+        await response.text()
+      );
+      return;
+    }
+    console.log(`[${MODULE_ID}] Snapshot posted (${reason}).`);
+  } catch (err) {
+    console.error(`[${MODULE_ID}] Snapshot post error`, err);
+  }
+}
+
+Hooks.once("init", () => {
+  game.settings.register(MODULE_ID, "bridgeUrl", {
+    name: "Bridge URL",
+    hint: "Local bridge service URL (default http://127.0.0.1:8787).",
+    scope: "world",
+    config: true,
+    type: String,
+    default: DEFAULT_BRIDGE_URL,
+  });
+
+  game.settings.register(MODULE_ID, "bridgeSecret", {
+    name: "Bridge shared secret",
+    hint: "Optional shared secret for Foundry → bridge posts.",
+    scope: "world",
+    config: true,
+    type: String,
+    default: "",
+  });
+});
+
+Hooks.once("ready", () => {
+  scheduleSnapshot("ready");
+});
+
+Hooks.on("createCombat", () => scheduleSnapshot("createCombat"));
+Hooks.on("deleteCombat", () => scheduleSnapshot("deleteCombat"));
+Hooks.on("combatStart", () => scheduleSnapshot("combatStart"));
+Hooks.on("combatRound", () => scheduleSnapshot("combatRound"));
+Hooks.on("combatTurn", () => scheduleSnapshot("combatTurn"));
+Hooks.on("updateCombat", () => scheduleSnapshot("updateCombat"));
+Hooks.on("updateCombatant", () => scheduleSnapshot("updateCombatant"));
+
+Hooks.on("updateActor", (actor, changes) => {
+  if (changes.system?.attributes?.hp || changes.effects) {
+    scheduleSnapshot("updateActor");
+  }
+});
+
+Hooks.on("createActiveEffect", () => scheduleSnapshot("createActiveEffect"));
+Hooks.on("deleteActiveEffect", () => scheduleSnapshot("deleteActiveEffect"));
+Hooks.on("updateActiveEffect", () => scheduleSnapshot("updateActiveEffect"));
+
+Hooks.on("controlToken", () => scheduleSnapshot("controlToken"));

--- a/foundryvtt-bridge/module.json
+++ b/foundryvtt-bridge/module.json
@@ -1,0 +1,18 @@
+{
+  "id": "foundryvtt-bridge",
+  "title": "Foundry Bridge Sync",
+  "description": "Posts combat snapshots to the local bridge service for read-only sync.",
+  "version": "0.1.0",
+  "authors": [
+    {
+      "name": "DND App" 
+    }
+  ],
+  "compatibility": {
+    "minimum": "10",
+    "verified": "12"
+  },
+  "scripts": [
+    "bridge.js"
+  ]
+}

--- a/lib/app/bridge_client.py
+++ b/lib/app/bridge_client.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+
+def _get_env(name: str, default: str = "") -> str:
+    value = os.getenv(name, "").strip()
+    if value:
+        return value
+    return default
+
+
+def _build_headers(token: str) -> Dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@dataclass
+class BridgeClient:
+    base_url: str
+    token: str
+    timeout_s: float = 3.0
+
+    @classmethod
+    def from_env(cls) -> "BridgeClient":
+        base_url = _get_env("BRIDGE_URL", "http://127.0.0.1:8787").rstrip("/")
+        token = _get_env("BRIDGE_TOKEN")
+        timeout_s = float(_get_env("BRIDGE_TIMEOUT", "3"))
+        return cls(base_url=base_url, token=token, timeout_s=timeout_s)
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.token)
+
+    def fetch_state(self) -> Optional[Dict[str, Any]]:
+        if not self.enabled:
+            print("[Bridge] BRIDGE_TOKEN is not set; skipping sync.")
+            return None
+        url = f"{self.base_url}/state"
+        response = requests.get(url, headers=_build_headers(self.token), timeout=self.timeout_s)
+        if response.status_code != 200:
+            print(f"[Bridge] GET /state failed: {response.status_code} {response.text}")
+            return None
+        return response.json()

--- a/lib/ui/ui.py
+++ b/lib/ui/ui.py
@@ -38,6 +38,7 @@ class InitiativeTracker(QMainWindow, Application):
             self.pop_lists()
         except Exception as e:
             print(f"[Startup] Failed to load last state: {e}")
+        self.start_bridge_polling()
 
     def initUI(self):
         self.central_widget = QWidget()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyqtdarktheme==2.1.0
 requests==2.32.3
 python-dotenv==1.1.0
 dotenv==0.9.9
+flask==3.0.3


### PR DESCRIPTION
### Motivation
- Provide a minimal Option B integration to enable a read-only Phase 1 sync from Foundry into the existing Python app.
- Expose a small local bridge service that Foundry can POST combat snapshots to while allowing the external Python app to securely fetch the latest state.
- Keep the implementation lightweight, incremental, and easy to test without any writes back into Foundry.

### Description
- Add a Flask-based bridge service at `bridge_service/` exposing `GET /health`, `GET /state`, `GET /version` and `POST /foundry/snapshot`, with bearer auth for external endpoints and optional `X-Bridge-Secret` for ingest; it stores the latest snapshot in-memory and can persist to a JSON file via `BRIDGE_SNAPSHOT_PATH` and is configurable via env vars such as `BRIDGE_HOST`, `BRIDGE_PORT`, `BRIDGE_TOKEN`, and `BRIDGE_INGEST_SECRET` (file: `bridge_service/app.py`).
- Provide a `deploy/bridge.service` systemd unit template to run the bridge on a Foundry host and document required env variables and quick curl tests in `README.md`.
- Add a Foundry VTT module in `foundryvtt-bridge/` (`module.json` + `bridge.js`) that registers hooks for combat/turn/round/HP/effect changes, builds the specified compact snapshot schema, and posts full snapshots to the local bridge (default `http://127.0.0.1:8787/foundry/snapshot`).
- Add a small app-side client `lib/app/bridge_client.py` and wire periodic polling into the app (`lib/app/app.py` and `lib/ui/ui.py`) to fetch `/state` using a bearer token from `BRIDGE_TOKEN`, log snapshot load events, and keep the change set minimal; update dependencies (`Pipfile`, `requirements.txt`) and README usage/install notes.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968035de4c48327b81c6062754ecf84)