### PR TITLE
Add Foundry bridge poller and conservative snapshot apply

### DIFF
--- a/lib/app/bridge_client.py
+++ b/lib/app/bridge_client.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import os
+import threading
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import requests
 
@@ -16,6 +17,61 @@ def _get_env(name: str, default: str = "") -> str:
 
 def _build_headers(token: str) -> Dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
+
+
+def get_bridge_poll_seconds() -> float:
+    value = _get_env("BRIDGE_POLL_SECONDS", "1")
+    try:
+        return max(0.25, float(value))
+    except ValueError:
+        return 1.0
+
+
+class BridgePoller:
+    def __init__(
+        self,
+        client: "BridgeClient",
+        poll_seconds: float,
+        on_snapshot: Callable[[Dict[str, Any]], None],
+    ) -> None:
+        self.client = client
+        self.poll_seconds = max(0.25, poll_seconds)
+        self.on_snapshot = on_snapshot
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._last_timestamp: Optional[str] = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def _is_duplicate(self, snapshot: Dict[str, Any]) -> bool:
+        timestamp = snapshot.get("timestamp") if isinstance(snapshot, dict) else None
+        if not timestamp:
+            return False
+        if timestamp == self._last_timestamp:
+            return True
+        self._last_timestamp = timestamp
+        return False
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                snapshot = self.client.fetch_state()
+            except Exception as exc:
+                print(f"[Bridge] Failed to fetch state: {exc}")
+                snapshot = None
+            if snapshot and not self._is_duplicate(snapshot):
+                try:
+                    self.on_snapshot(snapshot)
+                except Exception as exc:
+                    print(f"[Bridge] Failed to handle snapshot: {exc}")
+            self._stop_event.wait(self.poll_seconds)
 
 
 @dataclass


### PR DESCRIPTION
### Motivation
- Integrate read-only Foundry VTT snapshots into the desktop tracker while keeping physical dice/initiative authoritative and avoiding any automatic reordering or initiative changes.
- Ensure polling runs off the UI thread and that snapshot handling is marshalled safely to the Qt UI thread.

### Description
- Add `BridgePoller` and `get_bridge_poll_seconds` to `lib/app/bridge_client.py` to poll `GET /state` in a daemon thread, dedupe by snapshot `timestamp`, and honor `BRIDGE_POLL_SECONDS` from the environment.
- Wire polling into the application by replacing the old QTimer-based poll with the `BridgePoller` in `lib/app/app.py` and dispatch snapshots to the UI thread via `QTimer.singleShot(0, ...)` using a `_queue_bridge_snapshot` callback.
- Implement `handle_bridge_snapshot` and `_bridge_find_field_by_header` in `lib/ui/ui.py` to conservatively apply snapshots: update the active combatant label/highlight and update existing creatures' current and max HP by matching display names and table headers, without auto-adding creatures, sorting, rebuilding the table, or overriding initiatives, and add TODO hooks for optional auto-add and condition/effect mapping.
- Stop the bridge poller on UI close to clean up the background thread.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694878f4b883278922bdf97c77845e)