### PR TITLE
Add manual Foundry HP push command path

### DIFF
--- a/bridge_service/app.py
+++ b/bridge_service/app.py
@@ -3,7 +3,8 @@ import os
 import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Optional, Set, List
+from uuid import uuid4
 
 from flask import Flask, jsonify, request, make_response
 
@@ -44,6 +45,64 @@ class SnapshotStore:
             self.snapshot = snapshot
 
 
+@dataclass
+class CommandQueue:
+    commands: List[Dict[str, Any]]
+    lock: threading.Lock
+    path: str = ""
+
+    @classmethod
+    def from_path(cls, path: str) -> "CommandQueue":
+        queue = cls(commands=[], lock=threading.Lock(), path=path)
+        queue._load()
+        return queue
+
+    def _load(self) -> None:
+        if not self.path:
+            return
+        try:
+            with open(self.path, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            if isinstance(payload, dict):
+                commands = payload.get("commands", [])
+            else:
+                commands = payload
+            if isinstance(commands, list):
+                self.commands = [c for c in commands if isinstance(c, dict)]
+        except FileNotFoundError:
+            return
+        except Exception as exc:
+            print(f"[BridgeCmd] Failed to load commands: {exc}")
+
+    def _persist(self) -> None:
+        if not self.path:
+            return
+        dir_name = os.path.dirname(self.path)
+        if dir_name:
+            os.makedirs(dir_name, exist_ok=True)
+        try:
+            with open(self.path, "w", encoding="utf-8") as handle:
+                json.dump({"commands": self.commands}, handle, indent=2, sort_keys=True)
+        except Exception as exc:
+            print(f"[BridgeCmd] Failed to persist commands: {exc}")
+
+    def list(self) -> List[Dict[str, Any]]:
+        with self.lock:
+            return list(self.commands)
+
+    def enqueue(self, command: Dict[str, Any]) -> None:
+        with self.lock:
+            self.commands.append(command)
+            self._persist()
+
+    def ack(self, command_id: str) -> None:
+        with self.lock:
+            self.commands = [
+                command for command in self.commands if command.get("id") != command_id
+            ]
+            self._persist()
+
+
 def _load_env(name: str, default: Optional[str] = None) -> str:
     value = os.getenv(name, "").strip()
     if value:
@@ -65,6 +124,8 @@ def _parse_allowed_origins() -> Set[str]:
 def create_app() -> Flask:
     app = Flask(__name__)
     store = SnapshotStore()
+    commands_path = _load_env("BRIDGE_COMMANDS_PATH", "/var/lib/dnd-bridge/commands.json")
+    command_queue = CommandQueue.from_path(commands_path)
     allowed_origins = _parse_allowed_origins()
 
     def _require_bearer() -> Optional[Any]:
@@ -175,6 +236,74 @@ def create_app() -> Flask:
         print(f"[Bridge] Snapshot received world={world!r} combatants={len(combatants)}")
         return jsonify({"status": "ok"})
 
+    @app.post("/commands")
+    def enqueue_command() -> Any:
+        auth = _require_bearer()
+        if auth is not None:
+            return auth
+
+        payload = request.get_json(silent=True)
+        if not payload:
+            return jsonify({"error": "missing payload"}), 400
+
+        cmd_source = payload.get("source")
+        cmd_type = payload.get("type")
+        token_id = payload.get("tokenId")
+        hp_value = payload.get("hp")
+
+        if cmd_source != "app":
+            return jsonify({"error": "invalid source"}), 400
+        if cmd_type != "set_hp":
+            return jsonify({"error": "invalid type"}), 400
+        if not token_id:
+            return jsonify({"error": "missing tokenId"}), 400
+
+        try:
+            hp_value = int(hp_value)
+        except (TypeError, ValueError):
+            return jsonify({"error": "invalid hp"}), 400
+
+        command_id = payload.get("id") or str(uuid4())
+        actor_id = payload.get("actorId")
+        command = {
+            "id": command_id,
+            "source": cmd_source,
+            "type": cmd_type,
+            "tokenId": token_id,
+            "hp": hp_value,
+        }
+        if actor_id:
+            command["actorId"] = actor_id
+
+        command_queue.enqueue(command)
+        print(
+            "[BridgeCmd] enqueue "
+            f"id={command_id} type={cmd_type} tokenId={token_id} hp={hp_value}"
+        )
+        return jsonify({"ok": True, "id": command_id})
+
+    @app.get("/commands")
+    def list_commands() -> Any:
+        auth = _require_ingest_secret()
+        if auth is not None:
+            return auth
+        return jsonify({"commands": command_queue.list()})
+
+    @app.post("/commands/<command_id>/ack")
+    def ack_command(command_id: str) -> Any:
+        auth = _require_ingest_secret()
+        if auth is not None:
+            return auth
+
+        payload = request.get_json(silent=True) or {}
+        status = payload.get("status")
+        if status not in {"ok", "error"}:
+            return jsonify({"error": "invalid status"}), 400
+
+        command_queue.ack(command_id)
+        print(f"[BridgeCmd] ack id={command_id} status={status}")
+        return jsonify({"ok": True})
+
     return app
 
 
@@ -183,4 +312,3 @@ if __name__ == "__main__":
     port = int(_load_env("BRIDGE_PORT", "8787"))
     app = create_app()
     app.run(host=host, port=port, threaded=True)
-

--- a/lib/app/app.py
+++ b/lib/app/app.py
@@ -66,6 +66,7 @@ class Application:
         self.bridge_client = BridgeClient.from_env()
         self.bridge_snapshot: Optional[Dict[str, Any]] = None
         self.bridge_poller: Optional[BridgePoller] = None
+        self.bridge_ids: Dict[str, Dict[str, Optional[str]]] = {}
 
         self.player_view_live = True
         self.player_view_snapshot: Optional[Dict[str, Any]] = None

--- a/lib/app/bridge_client.py
+++ b/lib/app/bridge_client.py
@@ -141,3 +141,39 @@ class BridgeClient:
             body_preview = (response.text or "")[:300]
             print(f"[Bridge] GET /state JSON decode failed: {exc} body={body_preview}")
             return None
+
+    def send_set_hp(self, token_id: str, hp: int, actor_id: Optional[str] = None) -> bool:
+        if not self.enabled:
+            print("[BridgeCmd] send_set_hp ok=False reason=missing_token")
+            return False
+
+        url = f"{self.base_url}/commands"
+        payload: Dict[str, Any] = {
+            "source": "app",
+            "type": "set_hp",
+            "tokenId": token_id,
+            "hp": int(hp),
+        }
+        if actor_id:
+            payload["actorId"] = actor_id
+
+        ok = False
+        status = None
+        try:
+            response = requests.post(
+                url,
+                headers=_build_headers(self.token),
+                json=payload,
+                timeout=self.timeout_s,
+            )
+            status = response.status_code
+            ok = response.ok
+        except requests.RequestException as exc:
+            status = str(exc)
+            ok = False
+
+        print(
+            "[BridgeCmd] send_set_hp "
+            f"tokenId={token_id} hp={hp} ok={ok} status={status}"
+        )
+        return ok


### PR DESCRIPTION
### Motivation
- Provide a minimal end-to-end App → Bridge → Foundry command path to manually push current HP from the app into Foundry for validation before implementing auto-push.
- Keep the implementation minimal and temporary: single command type `set_hp`, simple persistence, and manual UI trigger.
- Prevent feedback loops by tagging outbound commands with `source:"app"` and ignoring snapshots from `source=="app"` in the app UI merge path.

### Description
- Added a persisted in-memory command queue with file backing and configurable path via `BRIDGE_COMMANDS_PATH` (default `/var/lib/dnd-bridge/commands.json`) in `bridge_service/app.py`, plus a `CommandQueue` helper and logging on enqueue/ack.
- Implemented bridge endpoints `POST /commands` (auth: bearer `BRIDGE_TOKEN`) to enqueue `set_hp` commands, `GET /commands` (auth: ingest secret) to list pending commands, and `POST /commands/<id>/ack` (auth: ingest secret) to acknowledge and remove commands; command `id` is generated via `uuid4()` when missing.
- Added Foundry-side polling in `foundryvtt-bridge/bridge.js` that `GET`s `/commands` every ~750ms, applies `set_hp` by tokenId (resolves token/actor and calls `actor.update({"system.attributes.hp.value": hp})`) and `POST`s ack to `/commands/<id>/ack`, with minimal logs and error acking.
- Added app-side send helper `BridgeClient.send_set_hp` in `lib/app/bridge_client.py` to `POST` `{

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6f362fa88327921e2968e833664f)