### PR TITLE
Add dedicated command poller and improve ingest auth logging

### DIFF
--- a/bridge_service/app.py
+++ b/bridge_service/app.py
@@ -143,6 +143,11 @@ def create_app() -> Flask:
             return None
         header = request.headers.get("X-Bridge-Secret", "")
         if header != secret:
+            reason = "missing" if not header else "mismatched"
+            print(
+                "[Bridge] ingest secret unauthorized "
+                f"path={request.path} reason={reason}"
+            )
             return jsonify({"error": "unauthorized"}), 401
         return None
 

--- a/foundryvtt-bridge/bridge.js
+++ b/foundryvtt-bridge/bridge.js
@@ -128,7 +128,7 @@ function buildCombatSnapshot() {
 let snapshotTimer = null;
 let hasLoggedSnapshotIds = false;
 let commandPollTimer = null;
-const COMMAND_POLL_MS = 750;
+const COMMAND_POLL_MS = 1000;
 
 function scheduleSnapshot(reason) {
   if (snapshotTimer) {
@@ -162,7 +162,7 @@ async function postSnapshot(reason) {
       );
       hasLoggedSnapshotIds = true;
     }
-    console.log('[${MODULE_ID}] POST -> ${endpoint}');
+    console.log(`[${MODULE_ID}] POST -> ${endpoint}`);
     const response = await fetch(endpoint, {
       method: "POST",
       headers: headers,
@@ -190,94 +190,35 @@ async function postSnapshot(reason) {
 // --------------------
 // Command polling
 // --------------------
-async function ackCommand(commandId, status, errorMessage) {
-  const bridgeUrl = getBridgeUrl();
-  const endpoint = bridgeUrl + "/commands/" + commandId + "/ack";
-  const secret = getBridgeSecret();
-  const headers = { "Content-Type": "application/json" };
-  if (secret) headers["X-Bridge-Secret"] = secret;
-
-  try {
-    await fetch(endpoint, {
-      method: "POST",
-      headers: headers,
-      body: JSON.stringify({
-        status: status,
-        error: errorMessage || undefined,
-      }),
-    });
-  } catch (err) {
-    console.error("BridgeCmd ack error", err);
-  }
-
-  console.log(`BridgeCmd ack id=${commandId} status=${status}`);
-}
-
-async function applySetHp(command) {
-  const tokenId = command.tokenId;
-  const hpValue = Number(command.hp);
-  if (!tokenId) {
-    throw new Error("missing tokenId");
-  }
-  if (!Number.isFinite(hpValue)) {
-    throw new Error("invalid hp");
-  }
-
-  const tokenDoc =
-    (canvas && canvas.scene && canvas.scene.tokens
-      ? canvas.scene.tokens.get(tokenId)
-      : null) ||
-    (canvas && canvas.tokens ? canvas.tokens.get(tokenId) : null);
-
-  const actor = tokenDoc ? tokenDoc.actor : null;
-  if (!actor) {
-    throw new Error("actor not found");
-  }
-  if (
-    !actor.system ||
-    !actor.system.attributes ||
-    !actor.system.attributes.hp
-  ) {
-    throw new Error("actor missing system.attributes.hp");
-  }
-
-  console.log(
-    `BridgeCmd apply set_hp id=${command.id} tokenId=${tokenId} hp=${hpValue}`
-  );
-  await actor.update({ "system.attributes.hp.value": hpValue });
-}
-
 async function pollCommandsOnce() {
+  const secret = getBridgeSecret();
+  if (!secret) {
+    return;
+  }
+
   const bridgeUrl = getBridgeUrl();
   const endpoint = bridgeUrl + "/commands";
-  const secret = getBridgeSecret();
-  const headers = {};
-  if (secret) headers["X-Bridge-Secret"] = secret;
+  const headers = { "X-Bridge-Secret": secret };
 
   try {
-    const response = await fetch(endpoint, { method: "GET", headers: headers });
+    const response = await fetch(endpoint, {
+      method: "GET",
+      headers: headers,
+      cache: "no-store",
+    });
     if (!response.ok) {
+      console.warn(
+        "[" + MODULE_ID + "] command poll failed (" + response.status + ")"
+      );
       return;
     }
     const payload = await response.json();
     const commands = payload && payload.commands ? payload.commands : [];
-    for (const command of commands) {
-      if (!command || command.type !== "set_hp") {
-        continue;
-      }
-      try {
-        await applySetHp(command);
-        await ackCommand(command.id, "ok");
-      } catch (err) {
-        await ackCommand(
-          command.id,
-          "error",
-          err && err.message ? err.message : String(err)
-        );
-      }
+    if (commands.length) {
+      console.log("[" + MODULE_ID + "] command poll received", commands);
     }
   } catch (err) {
-    console.error("BridgeCmd poll error", err);
+    console.error("[" + MODULE_ID + "] command poll error", err);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Foundry was intermittently issuing `GET /commands` requests without the required `X-Bridge-Secret`, causing 401s; the change makes polling-with-secret the only path so missing headers are impossible by design. 
- The bridge service needed better diagnostic logging when ingest secret checks fail to distinguish missing vs mismatched secrets without exposing secret values. 

### Description
- Added a single, dedicated command poller in `foundryvtt-bridge/bridge.js` that runs from `Hooks.once("ready", ...)`, polls `GET /commands` every 1s (`COMMAND_POLL_MS = 1000`), always includes `X-Bridge-Secret`, does nothing if the secret is empty, uses `cache: "no-store"`, and only logs received commands for Phase 1. 
- Removed the previous ad-hoc command processing/ack paths in the Foundry module so there is exactly one polling path that sends the ingest secret and never uses `Authorization: Bearer`. 
- Fixed the snapshot POST log interpolation in `foundryvtt-bridge/bridge.js` to use a template string: `console.log(`[${MODULE_ID}] POST -> ${endpoint}`)`.
- Hardened the bridge service in `bridge_service/app.py` so `_require_ingest_secret()` prints the `request.path` and whether the failure was `missing` or `mismatched` (without printing the secret) when returning 401. 

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7a1f86c88327b42006a9df363819)