### PR TITLE
Auto-push HP edits to Foundry

### DIFF
--- a/lib/ui/creature_table_model.py
+++ b/lib/ui/creature_table_model.py
@@ -29,6 +29,7 @@ class CreatureTableModel(QAbstractTableModel):
         self.active_creature_name = None
         self.selected_index = None
         self.view = parent
+        self.on_user_hp_edited = None
 
         # Build fields from a sample creature if not provided
         if fields is None and self.manager.creatures:
@@ -211,6 +212,7 @@ class CreatureTableModel(QAbstractTableModel):
 
         try:
             current = getattr(creature, attr)
+            old_value = current
 
             if isinstance(current, bool):
                 setattr(creature, attr, value == Qt.Checked)
@@ -226,6 +228,11 @@ class CreatureTableModel(QAbstractTableModel):
 
             if attr == "_init" and self.view:
                 QTimer.singleShot(0, self.view.handle_initiative_update)
+
+            if attr == "_curr_hp":
+                new_value = getattr(creature, attr)
+                if old_value != new_value and callable(self.on_user_hp_edited):
+                    self.on_user_hp_edited(name, creature, old_value, new_value)
 
             return True
         except (ValueError, TypeError, AttributeError):


### PR DESCRIPTION
### Motivation
- Automatically push user-initiated edits to a creature's current HP from the PyQt table to Foundry without requiring the context-menu push. 
- Ensure snapshot-driven updates do not trigger pushes (prevent feedback loops) and avoid re-sending identical values. 
- No-op if the creature lacks a `tokenId` so pushes are only attempted when Foundry token mapping exists.

### Description
- Add a lightweight model-level hook `on_user_hp_edited` to `CreatureTableModel` and capture the old value before applying edits in `setData`, calling the hook only when `_curr_hp` changes. 
- Wire the model hook in `InitiativeTracker` (`self.table_model.on_user_hp_edited = self._on_user_hp_edited`) and implement `_on_user_hp_edited` to log a single `[HP-AUTO]` line and call the existing `_push_hp_to_foundry`. 
- Add `self._applying_bridge_snapshot` flag and set it `True`/`False` around `_apply_bridge_snapshot` so user-edit callbacks are ignored while applying bridge snapshots. 
- Stop the previous duplicate commit-path push logic by making `on_commit_data` a no-op (the new model hook is the sole user-edit trigger), and rely on the existing `_push_hp_to_foundry` (which already guards for missing `tokenId`) to enqueue commands.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa34e8c84832783050eeed9319f05)