### PR TITLE
Auto-push HP from Damage/Heal buttons

### DIFF
--- a/lib/app/app.py
+++ b/lib/app/app.py
@@ -1304,6 +1304,25 @@ class Application:
                         if not succeeded:
                             self._break_concentration(creature)
 
+            post_hp = creature.curr_hp
+            if (
+                pre_hp != post_hp
+                and not getattr(self, "_applying_bridge_snapshot", False)
+                and callable(getattr(self, "_push_hp_to_foundry", None))
+            ):
+                token_info = getattr(self, "bridge_ids", {}) or {}
+                token_entry = token_info.get(creature_name)
+                token_id = token_entry.get("tokenId") if token_entry else None
+                if token_id:
+                    action = "heal" if positive else "damage"
+                    print(
+                        "[HP-AUTO] "
+                        f"source=button action={action} "
+                        f"name={creature_name} old={pre_hp} "
+                        f"new={post_hp} tokenId={token_id}"
+                    )
+                    self._push_hp_to_foundry(creature_name, creature)
+
         self.value_input.clear()
         self.update_table()
 


### PR DESCRIPTION
### Motivation
- Ensure HP changes made via the in-app `Damage` / `Heal` buttons are automatically pushed to Foundry using the same guarded path as table edits, avoiding snapshot feedback loops and no-ops when tokenId is missing or HP is unchanged.

### Description
- Added a small hook inside `apply_to_selected_creatures` in `lib/app/app.py` to snapshot `pre_hp`/`post_hp`, check `self._applying_bridge_snapshot`, verify `self._push_hp_to_foundry` is callable and that a `tokenId` exists, log the button-triggered push, and call `self._push_hp_to_foundry(name, creature)` when appropriate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa72347388327b7aeea9cb8a58a43)