### PR TITLE
Make command sweeper configurable, extract CommandQueue, and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ This repo includes a minimal bridge service and a Foundry module for sending com
 * `BRIDGE_SNAPSHOT_PATH` (optional file path to persist the latest snapshot)
 * `BRIDGE_COMMANDS_PATH` (optional file path to persist queued commands)
 * `BRIDGE_VERSION` (optional version string for `/version`)
+* `COMMAND_TTL_SECONDS` (optional; default `60`)
+* `COMMAND_SWEEP_INTERVAL_SECONDS` (optional; default `5`)
 
 **Run locally (pipenv):**
 ```bash
@@ -209,6 +211,8 @@ The bridge supports an app-to-Foundry command queue via `POST /commands`. When t
 * `BRIDGE_TOKEN` (required to authorize `/commands`)
 * `BRIDGE_COMMANDS_PATH` (optional; defaults to `/var/lib/dnd-bridge/commands.json`)
 * `BRIDGE_INGEST_SECRET` (required for Foundry polling `/commands` and `/commands/<id>/ack`)
+* `COMMAND_TTL_SECONDS` (optional; default `60`)
+* `COMMAND_SWEEP_INTERVAL_SECONDS` (optional; default `5`)
 
 
 ### Manual test checklist

--- a/bridge_service/__init__.py
+++ b/bridge_service/__init__.py
@@ -1,3 +1,10 @@
-from bridge_service.app import create_app
+from typing import Any
+
+
+def create_app(*args: Any, **kwargs: Any):
+    from bridge_service.app import create_app as _create_app
+
+    return _create_app(*args, **kwargs)
+
 
 __all__ = ["create_app"]

--- a/bridge_service/command_queue.py
+++ b/bridge_service/command_queue.py
@@ -1,0 +1,77 @@
+import json
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class CommandQueue:
+    """In-memory command queue."""
+
+    items: List[Dict[str, Any]] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    persist_path: Optional[str] = None
+
+    def load(self) -> None:
+        if not self.persist_path:
+            return
+        try:
+            with open(self.persist_path, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            if isinstance(payload, list):
+                with self.lock:
+                    self.items = [item for item in payload if isinstance(item, dict)]
+        except FileNotFoundError:
+            return
+        except Exception as exc:
+            print(f"[Bridge] Failed to load commands: {exc}")
+
+    def _persist(self) -> None:
+        if not self.persist_path:
+            return
+        try:
+            with open(self.persist_path, "w", encoding="utf-8") as handle:
+                json.dump(self.items, handle, indent=2, sort_keys=True)
+        except Exception as exc:
+            print(f"[Bridge] Failed to persist commands: {exc}")
+
+    def put(self, cmd: Dict[str, Any]) -> None:
+        with self.lock:
+            self.items.append(cmd)
+            self._persist()
+
+    def get_next(self) -> Optional[Dict[str, Any]]:
+        with self.lock:
+            return self.items[0] if self.items else None
+
+    def ack(self, cmd_id: str) -> bool:
+        with self.lock:
+            for i, cmd in enumerate(self.items):
+                if cmd.get("id") == cmd_id:
+                    self.items.pop(i)
+                    self._persist()
+                    return True
+            return False
+
+    def sweep_head_if_expired(self, max_age_seconds: float) -> Optional[Tuple[Dict[str, Any], float]]:
+        now = datetime.now(timezone.utc)
+        with self.lock:
+            if not self.items:
+                return None
+            head = self.items[0]
+            timestamp = head.get("timestamp")
+            if not isinstance(timestamp, str):
+                return None
+            try:
+                created = datetime.fromisoformat(timestamp)
+            except ValueError:
+                return None
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
+            age_seconds = (now - created).total_seconds()
+            if age_seconds <= max_age_seconds:
+                return None
+            self.items.pop(0)
+            self._persist()
+            return head, age_seconds

--- a/tests/test_command_queue_sweeper.py
+++ b/tests/test_command_queue_sweeper.py
@@ -1,0 +1,26 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from bridge_service.command_queue import CommandQueue
+
+
+class CommandQueueSweeperTests(unittest.TestCase):
+    def test_sweeper_removes_expired_head(self):
+        queue = CommandQueue()
+        now = datetime.now(timezone.utc)
+        old_timestamp = (now - timedelta(seconds=120)).isoformat()
+        fresh_timestamp = (now - timedelta(seconds=10)).isoformat()
+
+        queue.put({"id": "cmd-old", "type": "test", "timestamp": old_timestamp})
+        queue.put({"id": "cmd-new", "type": "test", "timestamp": fresh_timestamp})
+
+        swept = queue.sweep_head_if_expired(60)
+        self.assertIsNotNone(swept)
+        cmd, age_seconds = swept
+        self.assertEqual(cmd["id"], "cmd-old")
+        self.assertGreater(age_seconds, 60)
+        self.assertEqual(queue.get_next()["id"], "cmd-new")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make the background command sweeper configurable via environment variables so TTL and sweep interval can be tuned without code changes. 
- Remove Flask import side-effects from testable modules so unit tests can run without `flask` installed. 
- Add a minimal automated test to verify expired-head commands are removed by the sweeper logic. 

### Description
- Introduced `COMMAND_TTL_SECONDS` and `COMMAND_SWEEP_INTERVAL_SECONDS` env wiring and used them in the sweeper loop (defaults `60` and `5`).
- Extracted the in-memory command queue (with optional on-disk persistence) into `bridge_service/command_queue.py` and preserved `load`, `_persist`, `put`, `get_next`, `ack`, and `sweep_head_if_expired` behavior. 
- Updated `bridge_service/app.py` to use the new `CommandQueue`, call `commands.load()`, start the sweeper thread, and print a log line when a command is swept. 
- Adjusted `bridge_service/__init__.py` to lazily import `create_app` to avoid importing `flask` at package import time. 
- Documented the new env vars in `README.md` and added `tests/test_command_queue_sweeper.py` which enqueues an old and a fresh command and asserts the old head is swept. 

### Testing
- Ran `python -m unittest tests/test_command_queue_sweeper.py` which initially failed due to `ModuleNotFoundError: No module named 'flask'` while importing the package. 
- After extracting `CommandQueue` and making `create_app` a lazy import in `bridge_service.__init__`, `python -m unittest tests/test_command_queue_sweeper.py` succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712ffdfccc8327906569b09519ebc1)