### PR TITLE
Enable condition edits in app to sync to Foundry

### DIFF
--- a/lib/app/bridge_dev.py
+++ b/lib/app/bridge_dev.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from app.bridge_client import BridgeClient
+
+
+def _format_effect(effect: Dict[str, Any]) -> str:
+    label = effect.get("label") or ""
+    effect_id = effect.get("id") or ""
+    return f"{label} ({effect_id})".strip()
+
+
+def _print_conditions(snapshot: Dict[str, Any]) -> None:
+    combatants = snapshot.get("combatants", [])
+    if not isinstance(combatants, list) or not combatants:
+        print("[BridgeDev] No combatants in snapshot.")
+        return
+    print("[BridgeDev] Current conditions:")
+    for combatant in combatants:
+        if not isinstance(combatant, dict):
+            continue
+        name = combatant.get("name", "<unknown>")
+        effects = combatant.get("effects", []) or []
+        if not effects:
+            print(f"  - {name}: (no effects)")
+            continue
+        effect_list = ", ".join(_format_effect(effect) for effect in effects)
+        print(f"  - {name}: {effect_list}")
+
+
+def _select_target(snapshot: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    combatants = snapshot.get("combatants", [])
+    if not isinstance(combatants, list) or not combatants:
+        return None
+    for combatant in combatants:
+        if isinstance(combatant, dict):
+            return combatant
+    return None
+
+
+def main() -> None:
+    client = BridgeClient.from_env()
+    if not client.enabled:
+        print("[BridgeDev] BRIDGE_TOKEN is not set; aborting.")
+        return
+
+    snapshot = client.fetch_state()
+    if not snapshot:
+        print("[BridgeDev] No snapshot available.")
+        return
+
+    _print_conditions(snapshot)
+
+    target = _select_target(snapshot)
+    if not target:
+        print("[BridgeDev] No combatants available for command test.")
+        return
+
+    token_id = target.get("tokenId")
+    actor_id = target.get("actorId")
+    combatant_id = target.get("combatantId")
+
+    effects = target.get("effects", []) if isinstance(target.get("effects", []), list) else []
+    env_effect_id = os.getenv("BRIDGE_TEST_EFFECT_ID", "").strip() or None
+    env_label = os.getenv("BRIDGE_TEST_CONDITION_LABEL", "").strip() or None
+    effect_id = env_effect_id or (effects[0].get("id") if effects else None)
+    label = env_label or (effects[0].get("label") if effects else None)
+
+    if effect_id or label:
+        client.send_add_condition(
+            effect_id=effect_id,
+            label=label,
+            token_id=token_id,
+            actor_id=actor_id,
+        )
+    else:
+        print("[BridgeDev] No effectId/label available for add_condition.")
+
+    if effect_id or label:
+        client.send_remove_condition(
+            effect_id=effect_id,
+            label=label,
+            token_id=token_id,
+            actor_id=actor_id,
+        )
+    else:
+        print("[BridgeDev] No effectId/label available for remove_condition.")
+
+    initiative = target.get("initiative")
+    try:
+        initiative_value = int(initiative) if initiative is not None else 0
+    except (TypeError, ValueError):
+        initiative_value = 0
+    client.send_set_initiative(
+        initiative=initiative_value,
+        combatant_id=combatant_id,
+        token_id=token_id,
+        actor_id=actor_id,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ui/ui.py
+++ b/lib/ui/ui.py
@@ -446,9 +446,15 @@ class InitiativeTracker(QMainWindow, Application):
             return
 
         if chosen == clear_conditions_action:
+            removed = list(getattr(creature, "conditions", []) or [])
             creature.conditions = []
             self.table_model.refresh()
             self.update_table()
+            if hasattr(self, "_enqueue_bridge_condition_delta"):
+                try:
+                    self._enqueue_bridge_condition_delta(creature, [], removed)
+                except Exception:
+                    pass
             return
 
         if chosen == remove_action:


### PR DESCRIPTION
### Motivation

- Provide two-way condition syncing by allowing the app to enqueue `add_condition`/`remove_condition` commands so condition edits in the PyQt UI are applied in Foundry. 
- Reuse the existing bridge command queue and Foundry snapshot data (including `combatantId`/`effects`) so the app and Foundry can remain in sync for initiative, HP, and conditions.

### Description

- Wire the conditions dropdown to detect deltas and call the new app method `_enqueue_bridge_condition_delta` when conditions change or are cleared, and update the context-menu clear action to enqueue removes (files: `lib/ui/conditions_dropdown.py`, `lib/ui/ui.py`).
- Add `_enqueue_bridge_condition_delta` to the application to resolve `tokenId`/`actorId`/`combatantId`, map existing `foundry_effects` to effect ids, and call bridge client helpers to enqueue `add_condition`/`remove_condition` commands (file: `lib/app/app.py`).
- Extend `BridgeClient` with `send_add_condition`, `send_remove_condition`, `send_set_initiative`, and a shared `_post_command` helper to POST normalized `source/type/payload` commands to `/commands` with redacted logs (file: `lib/app/bridge_client.py`).
- Enhance the Foundry module `foundryvtt-bridge/bridge.js` to include `combatantId` and richer `effects[]` metadata in snapshots, and add handlers to apply `set_initiative`, `add_condition`, and `remove_condition` commands (including helpers `resolveCombatant`, `resolveStatusEffectById/Label`, and `resolveConditionTemplate`).
- Add a small dev helper `lib/app/bridge_dev.py` to print snapshot conditions and exercise `add_condition`, `remove_condition`, and `set_initiative`, and update `README.md` to document the snapshot schema and manual test checklist.

### Testing

- No automated tests were executed for these changes. 
- A manual test checklist was added to `README.md` and a dev helper `lib/app/bridge_dev.py` was provided for exercising `add_condition`, `remove_condition`, and `set_initiative` against a running bridge and Foundry instance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971369616788327a536973b1e4d3af2)