### PR TITLE
Fix initiative bridge enqueue wiring

### DIFF
--- a/lib/app/app.py
+++ b/lib/app/app.py
@@ -309,14 +309,9 @@ class Application:
         )
 
     def _enqueue_bridge_set_initiative(self, creature_name: str, initiative: int) -> None:
-        # 0) Quick visibility
-        print(f"[Bridge][DBG] enqueue_set_initiative name={creature_name!r} initiative={initiative!r}")
-
         if not getattr(self, "bridge_client", None):
             print("[Bridge][DBG] bridge_client missing; cannot send set_initiative")
             return
-
-        print(f"[Bridge][DBG] bridge_client.enabled={getattr(self.bridge_client, 'enabled', None)} base_url={getattr(self.bridge_client, 'base_url', None)}")
 
         if not self.bridge_client.enabled:
             print("[Bridge][DBG] bridge_client disabled; skipping set_initiative")
@@ -350,13 +345,17 @@ class Application:
             token_id = token_id or combatant.get("tokenId")
             actor_id = actor_id or combatant.get("actorId")
 
-        print(f"[Bridge][DBG] resolved ids name={creature_name!r} combatant_id={combatant_id!r} token_id={token_id!r} actor_id={actor_id!r}")
-
         if not combatant_id and not token_id and not actor_id:
             print(f"[Bridge][DBG] missing all ids for {creature_name!r}; skipping set_initiative")
             return
 
         # 3) Send command
+        print(
+            "[Bridge] enqueue set_initiative "
+            f"name={creature_name!r} initiative={initiative!r} "
+            f"combatant_id={combatant_id!r} token_id={token_id!r} "
+            f"actor_id={actor_id!r} post=attempt"
+        )
         self.bridge_client.send_set_initiative(
             initiative=int(initiative),
             combatant_id=str(combatant_id) if combatant_id else None,

--- a/lib/app/bridge_client.py
+++ b/lib/app/bridge_client.py
@@ -164,11 +164,15 @@ class BridgeClient:
         headers = _build_headers(self.token)
         headers["Content-Type"] = "application/json"
         try:
-            print(f"[Bridge][DBG] POST {url} json={payload}")
+            if command_type == "set_initiative":
+                print(f"[Bridge][DBG] POST {url} type=set_initiative json={payload}")
             response = requests.post(
                 url, json=cmd, headers=headers, timeout=self.timeout_s
             )
-            print(f"[Bridge][DBG] POST /commands status={response.status_code} body={response.text[:200]}")
+            if command_type == "set_initiative":
+                print(
+                    f"[Bridge][DBG] POST /commands status={response.status_code} body={response.text[:200]}"
+                )
         except requests.RequestException as exc:
             print(f"[Bridge] POST /commands failed: {exc}")
             return False

--- a/lib/ui/ui.py
+++ b/lib/ui/ui.py
@@ -74,7 +74,7 @@ class InitiativeTracker(QMainWindow, Application):
         self.label_layout.addWidget(self.player_view_toggle)
 
         # === TABLE AREA (under labels) ===
-        self.table_model = CreatureTableModel(self.manager, parent=self)
+        self.table_model = CreatureTableModel(self.manager, parent=self, bridge_owner=self)
         self.table = QTableView(self)
         self.table.setModel(self.table_model)
         self.table.itemDelegate().commitData.connect(self.on_commit_data)


### PR DESCRIPTION
### Motivation
- Initiative edits in the table were updating the local model but not reliably enqueued to the bridge because the model used the wrong reference (`model.view` can be a `QTableView`) instead of the main controller/bridge owner.

### Description
- Add an explicit `bridge_owner` parameter to `CreatureTableModel` and store it on the model as `self.bridge_owner` so the model can target the application controller when pushing initiative changes.
- In `CreatureTableModel.setData()` route initiative pushes through `target = self.bridge_owner or self.view` and call `target._enqueue_bridge_set_initiative(...)` without touching HP or condition apply/remove logic.
- Also schedule initiative refreshes on the same `target` by routing the `handle_initiative_update` call through `bridge_owner` when present.
- In `lib/ui/ui.py` pass `bridge_owner=self` into the `CreatureTableModel` constructor so the main controller becomes the stable target.
- Add a focused enqueue debug line in `Application._enqueue_bridge_set_initiative` showing `name`, `initiative`, resolved ids, and that a POST was attempted, and scope `BridgeClient._post_command` POST debug output to `set_initiative` only to reduce log noise.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69726f5194ec832795ecf3ca166818f7)