### PR TITLE
Auto-apply initiative updates (remove Apply/Skip prompt)

### DIFF
--- a/lib/app/app.py
+++ b/lib/app/app.py
@@ -996,35 +996,18 @@ class Application:
 
     def handle_initiative_update(self):
         """
-        Prompt the user after an initiative edit and ensure the active UI/statblock reflect the lastest turn order regardless of the dialog choice.
+        Auto-apply initiative edits and ensure the active UI/statblock reflect the latest turn order.
         """
         if getattr(self, "_initiative_dialog_open", False):
             return
         
         self._initiative_dialog_open = True
         try:
-            dialog = QMessageBox(self)
-            dialog.setWindowTitle("Initiaitve Changed")
-            dialog.setText("Initiaitves were updated. Rebuild the turn order now?")
-            dialog.setIcon(QMessageBox.Question)
-            apply_btn = dialog.addButton("Apply", QMessageBox.AcceptRole)
-            dialog.addButton("Skip", QMessageBox.RejectRole)
-            dialog.exec_()
-
-            applied = dialog.clickedButton() is apply_btn
-
-            if applied:
-                self.manager.sort_creatures()
-                self.build_turn_order()
-                self.update_table()
-                QMessageBox.information(
-                    self,
-                    "Initiatives Updated",
-                    "Initiatives applied and turn order rebuilt",
-                )
-            else:
+            self.manager.sort_creatures()
+            self.build_turn_order()
+            if hasattr(self, "table_model") and self.table_model:
                 self.table_model.refresh()
-                self.update_table()
+            self.update_table()
         finally:
             self._initiative_dialog_open = False
 


### PR DESCRIPTION
### Motivation
- Initiative edits coming back from the Foundry bridge currently trigger a modal Apply/Skip prompt which interrupts workflow and requires a user click to rebuild the turn order.
- The goal is to auto-apply bridge-driven initiative updates while preserving all existing HP/condition sync, bridge enqueue behavior, and the existing `Application.on_commit_data()`/QTimer deferral wiring.

### Description
- Removed the QMessageBox Apply/Skip flow in `Application.handle_initiative_update` and replaced it with immediate application: call `manager.sort_creatures()`, `build_turn_order()`, refresh `table_model` if present, and `update_table()`.
- Kept the existing `_initiative_dialog_open` guard to avoid re-entrancy during snapshot application.
- Did not modify any code paths that enqueue `set_initiative` (those remain in the table model), nor any HP or condition sync logic, bridge client logic, or snapshot parsing beyond using the canonical `creature.initiative` that is already set in `_apply_bridge_snapshot`.
- This change updates the manager/creature canonical initiative field and refreshes/sorts UI state without issuing new `set_initiative` calls, avoiding a re-enqueue loop.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697276cbcb008327a3ec7a66df5106bb)