### PR TITLE
Auto-add Foundry combatants from snapshot into initiative list

### DIFF
--- a/lib/app/app.py
+++ b/lib/app/app.py
@@ -124,6 +124,7 @@ class Application:
         if not isinstance(combatants, list):
             return
 
+        added_combatants = self._ensure_foundry_combatants_present(combatants)
         updated_initiative = False
         updated_active = False
         for creature_name, creature in self.manager.creatures.items():
@@ -167,10 +168,138 @@ class Application:
                 self.current_creature_name = active_name
                 updated_active = True
 
-        if updated_initiative or updated_active:
+        if added_combatants:
+            self.build_turn_order()
+            self.update_table()
+            self.pop_lists()
+        elif updated_initiative or updated_active:
             self.build_turn_order()
         else:
             self.update_active_ui()
+
+    def _ensure_foundry_combatants_present(
+        self, combatants: List[Dict[str, Any]]
+    ) -> bool:
+        if not getattr(self, "manager", None) or not getattr(self.manager, "creatures", None):
+            return False
+
+        def _normalize_id(value: Any) -> Optional[str]:
+            if value is None:
+                return None
+            if isinstance(value, str) and not value.strip():
+                return None
+            return str(value)
+
+        existing_by_combatant_id: Dict[str, I_Creature] = {}
+        existing_by_token_id: Dict[str, I_Creature] = {}
+        existing_by_actor_id: Dict[str, I_Creature] = {}
+        unmapped_by_name: Dict[str, List[I_Creature]] = {}
+        for creature in self.manager.creatures.values():
+            combatant_id = _normalize_id(
+                getattr(creature, "foundry_combatant_id", None)
+                or getattr(creature, "combatant_id", None)
+            )
+            token_id = _normalize_id(
+                getattr(creature, "foundry_token_id", None)
+                or getattr(creature, "token_id", None)
+            )
+            actor_id = _normalize_id(
+                getattr(creature, "foundry_actor_id", None)
+                or getattr(creature, "actor_id", None)
+            )
+            if combatant_id:
+                existing_by_combatant_id[combatant_id] = creature
+            if token_id:
+                existing_by_token_id[token_id] = creature
+            if actor_id:
+                existing_by_actor_id[actor_id] = creature
+            if not combatant_id and not token_id and not actor_id:
+                name_key = self._normalize_bridge_name(getattr(creature, "name", ""))
+                if name_key:
+                    unmapped_by_name.setdefault(name_key, []).append(creature)
+
+        added = False
+        for combatant in combatants:
+            if not isinstance(combatant, dict):
+                continue
+            name = combatant.get("name") or ""
+            name_key = self._normalize_bridge_name(str(name))
+            combatant_id = _normalize_id(combatant.get("combatantId"))
+            token_id = _normalize_id(combatant.get("tokenId"))
+            actor_id = _normalize_id(combatant.get("actorId"))
+
+            existing = None
+            if combatant_id and combatant_id in existing_by_combatant_id:
+                existing = existing_by_combatant_id[combatant_id]
+            elif token_id and token_id in existing_by_token_id:
+                existing = existing_by_token_id[token_id]
+            elif actor_id and actor_id in existing_by_actor_id:
+                existing = existing_by_actor_id[actor_id]
+            elif name_key and unmapped_by_name.get(name_key):
+                existing = unmapped_by_name[name_key].pop(0)
+
+            if existing:
+                if combatant_id and not getattr(existing, "foundry_combatant_id", None):
+                    setattr(existing, "foundry_combatant_id", combatant_id)
+                if token_id and not getattr(existing, "foundry_token_id", None):
+                    setattr(existing, "foundry_token_id", token_id)
+                if actor_id and not getattr(existing, "foundry_actor_id", None):
+                    setattr(existing, "foundry_actor_id", actor_id)
+                continue
+
+            if not name:
+                continue
+
+            creature = I_Creature(_name=str(name))
+            if combatant_id:
+                setattr(creature, "foundry_combatant_id", combatant_id)
+            if token_id:
+                setattr(creature, "foundry_token_id", token_id)
+            if actor_id:
+                setattr(creature, "foundry_actor_id", actor_id)
+
+            initiative = combatant.get("initiative")
+            if initiative is not None:
+                creature.initiative = initiative
+
+            hp = combatant.get("hp", {})
+            if isinstance(hp, dict):
+                curr_hp = hp.get("value")
+                max_hp = hp.get("max")
+                if curr_hp is not None:
+                    try:
+                        creature.curr_hp = int(curr_hp)
+                    except (TypeError, ValueError):
+                        pass
+                if max_hp is not None:
+                    try:
+                        creature.max_hp = int(max_hp)
+                    except (TypeError, ValueError):
+                        pass
+
+            effects = combatant.get("effects", [])
+            if isinstance(effects, list):
+                setattr(creature, "foundry_effects", effects)
+                labels = [effect.get("label") for effect in effects if effect.get("label")]
+                creature.conditions = labels
+
+            base_name = creature.name
+            counter = 1
+            while creature.name in self.manager.creatures:
+                creature.name = f"{base_name}_{counter}"
+                counter += 1
+
+            self.manager.add_creature(creature)
+            added = True
+
+            if combatant_id:
+                existing_by_combatant_id[combatant_id] = creature
+            if token_id:
+                existing_by_token_id[token_id] = creature
+            if actor_id:
+                existing_by_actor_id[actor_id] = creature
+
+        return added
 
     # -----------------------
     # Core ordering utilities

--- a/lib/app/creature.py
+++ b/lib/app/creature.py
@@ -51,6 +51,9 @@ class I_Creature:
     _death_stable: bool = field(default=False)
     _death_saves_prompt: bool = field(default=False)
     _active: bool = field(default=True)
+    _foundry_combatant_id: Optional[str] = field(default=None)
+    _foundry_token_id: Optional[str] = field(default=None)
+    _foundry_actor_id: Optional[str] = field(default=None)
 
     def __gt__(self, other: I_Creature) -> bool:
         if not isinstance(other, I_Creature):
@@ -93,7 +96,10 @@ class I_Creature:
             "_death_failures": self._death_failures,
             "_death_stable": self._death_stable,
             "_death_saves_prompt": self._death_saves_prompt,
-            "_active": self._active
+            "_active": self._active,
+            "_foundry_combatant_id": self._foundry_combatant_id,
+            "_foundry_token_id": self._foundry_token_id,
+            "_foundry_actor_id": self._foundry_actor_id,
         }
 
     @staticmethod
@@ -111,6 +117,9 @@ class I_Creature:
         death_stable = data.get("_death_stable", False)
         death_saves_prompt = data.get("_death_saves_prompt", False)
         active = data.get("_active", True)
+        foundry_combatant_id = data.get("_foundry_combatant_id")
+        foundry_token_id = data.get("_foundry_token_id")
+        foundry_actor_id = data.get("_foundry_actor_id")
         # print("[LOAD CREATURE]", data["_name"])
         # print("  _innate_slots_used:", data.get("_innate_slots_used"))
         # print("  _spell_slots_used:", data.get("_spell_slots_used"))
@@ -141,7 +150,10 @@ class I_Creature:
                 death_successes=death_successes,
                 death_failures=death_failures,
                 death_stable=death_stable,
-                active=active
+                active=active,
+                foundry_combatant_id=foundry_combatant_id,
+                foundry_token_id=foundry_token_id,
+                foundry_actor_id=foundry_actor_id,
             )
         elif creature_type == CreatureType.MONSTER:
             if player_visible is None:
@@ -166,7 +178,10 @@ class I_Creature:
                 spell_slots_used=spell_slots_used,
                 innate_slots_used=innate_slots_used,
                 death_saves_prompt=bool(death_saves_prompt) if death_saves_prompt is not None else False,
-                active=active
+                active=active,
+                foundry_combatant_id=foundry_combatant_id,
+                foundry_token_id=foundry_token_id,
+                foundry_actor_id=foundry_actor_id,
             )
         else:
             return I_Creature(**data)
@@ -284,7 +299,8 @@ class Monster(I_Creature):
                  movement=0, action=False, bonus_action=False, reaction=False,
                  notes='', public_notes='', player_visible=True, conditions=None, status_time='',
                  spell_slots=None, innate_slots=None, spell_slots_used=None,
-                 innate_slots_used=None, death_saves_prompt=False, active=True):
+                 innate_slots_used=None, death_saves_prompt=False, active=True,
+                 foundry_combatant_id=None, foundry_token_id=None, foundry_actor_id=None):
         super().__init__(
             _type=CreatureType.MONSTER,
             _name=name,
@@ -306,7 +322,10 @@ class Monster(I_Creature):
             _spell_slots_used=spell_slots_used or {},
             _innate_slots_used=innate_slots_used or {},
             _death_saves_prompt=bool(death_saves_prompt),
-            _active=active
+            _active=active,
+            _foundry_combatant_id=foundry_combatant_id,
+            _foundry_token_id=foundry_token_id,
+            _foundry_actor_id=foundry_actor_id,
         )
 
 
@@ -316,7 +335,8 @@ class Player(I_Creature):
                  object_interaction=False, notes='', public_notes='', player_visible=True,
                  conditions=None, status_time='',
                  spell_slots=None, innate_slots=None, spell_slots_used=None,
-                 innate_slots_used=None, death_successes=0, death_failures=0, death_stable=False, active=True):
+                 innate_slots_used=None, death_successes=0, death_failures=0, death_stable=False, active=True,
+                 foundry_combatant_id=None, foundry_token_id=None, foundry_actor_id=None):
         super().__init__(
             _type=CreatureType.PLAYER,
             _name=name,
@@ -342,5 +362,8 @@ class Player(I_Creature):
             _death_failures=death_failures,
             _death_stable=death_stable,
             _death_saves_prompt=True,
-            _active=active
+            _active=active,
+            _foundry_combatant_id=foundry_combatant_id,
+            _foundry_token_id=foundry_token_id,
+            _foundry_actor_id=foundry_actor_id,
         )

--- a/lib/ui/creature_table_model.py
+++ b/lib/ui/creature_table_model.py
@@ -45,6 +45,9 @@ class CreatureTableModel(QAbstractTableModel):
                 "_death_stable",
                 "_death_saves_prompt",
                 "_active",
+                "_foundry_combatant_id",
+                "_foundry_token_id",
+                "_foundry_actor_id",
             }
             sample = next(iter(self.manager.creatures.values()))
             self.fields = [f.name for f in dataclass_fields(sample) if f.name not in excluded]
@@ -356,6 +359,9 @@ class CreatureTableModel(QAbstractTableModel):
             "_death_stable",
             "_death_saves_prompt",
             "_active",
+            "_foundry_combatant_id",
+            "_foundry_token_id",
+            "_foundry_actor_id",
         }
         sample = next(iter(self.manager.creatures.values()))
         self.fields = [f.name for f in dataclass_fields(sample) if f.name not in excluded]
@@ -388,6 +394,9 @@ class CreatureTableModel(QAbstractTableModel):
                 "_innate_slots_used",
                 "_death_saves_prompt",
                 "_active",
+                "_foundry_combatant_id",
+                "_foundry_token_id",
+                "_foundry_actor_id",
             }
             sample = next(iter(self.manager.creatures.values()))
             self.fields = [f.name for f in dataclass_fields(sample) if f.name not in excluded]


### PR DESCRIPTION
### Motivation
- Keep the app’s initiative list in sync with Foundry snapshots by ensuring every combatant present in Foundry appears in the app (membership add-only for now). 
- Use stable identifiers to avoid duplicates and preserve existing update behavior for HP/initiative/conditions/turn state.

### Description
- Added a small isolated helper `Application._ensure_foundry_combatants_present(combatants)` that runs during snapshot merge and auto-adds any Foundry combatant not already represented in `CreatureManager` while initializing initiative, hp (when provided), and conditions/effects. 
- Matching prefers `combatantId` then `tokenId` then `actorId` to avoid duplicates and falls back to a name-based match only for existing creatures lacking any Foundry IDs; newly added creatures are named uniquely to avoid collisions. 
- Persisted Foundry identifiers on creatures by adding `_foundry_combatant_id`, `_foundry_token_id`, and `_foundry_actor_id` to `I_Creature` and threading those through `Player`/`Monster` constructors and `to_dict`/`from_dict` for backward-compatible serialization. 
- Kept the UI unchanged by excluding the new Foundry ID fields from table columns in `CreatureTableModel` and by refreshing turn order/table/lists only when new combatants are added (no prompts or column layout changes). 

Files changed:
- `lib/app/app.py` — added the helper and wired it into the snapshot merge flow.
- `lib/app/creature.py` — added Foundry ID fields and serialization/load support for backward compatibility.
- `lib/ui/creature_table_model.py` — excluded the new fields from the table model so columns/layout remain unchanged.

Identifier storage and duplicate prevention:
- Preference order: `combatantId` (preferred) → `tokenId` → `actorId`.
- Stored on creatures as `_foundry_combatant_id`, `_foundry_token_id`, `_foundry_actor_id` (serialized in `to_dict`/`from_dict`).

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738d73853c8327a7cf9e015c88d813)