### PR TITLE
Use manager ordering for creature table

### DIFF
--- a/lib/ui/creature_table_model.py
+++ b/lib/ui/creature_table_model.py
@@ -57,7 +57,7 @@ class CreatureTableModel(QAbstractTableModel):
         else:
             self.fields = fields or []
 
-        self.creature_names = list(self.manager.creatures.keys())
+        self.creature_names = self.manager.ordered_names()
 
     def rowCount(self, parent=QModelIndex()):
         return len(self.creature_names)
@@ -387,16 +387,7 @@ class CreatureTableModel(QAbstractTableModel):
         self.layoutChanged.emit()
 
     def refresh(self):
-        # Always sort by initiative desc
-        if hasattr(self.manager, "ordered_items"):
-            sorted_items = self.manager.ordered_items()
-        else:
-            sorted_items = sorted(
-                self.manager.creatures.items(),
-                key=lambda item: item[1].initiative,
-                reverse=True,
-            )
-        self.creature_names = [name for name, _ in sorted_items]
+        self.creature_names = self.manager.ordered_names()
 
         # If fields were never initialized (edge-case), rebuild them consistently
         if not self.fields and self.manager.creatures:


### PR DESCRIPTION
### Motivation
- The UI was building its own creature ordering (grouping missing initiatives by type) instead of using the manager's canonical ordering, so combatants with missing initiative were displayed in separate type groups rather than a single alphabetical list.

### Description
- Replace UI-side sorting with the manager's canonical ordering by calling `self.manager.ordered_names()` at model initialization and in `refresh()`, removing the creature-table's own sorting logic; file changed: `lib/ui/creature_table_model.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a41a3eb88327ab7b0512cc01a82d)