### PR TITLE
Distinguish Players vs Monsters from Foundry snapshots and normalize ‘#N’ names

### DIFF
--- a/foundryvtt-bridge/bridge.js
+++ b/foundryvtt-bridge/bridge.js
@@ -65,6 +65,8 @@ function buildCombatSnapshot() {
       combatantId: c.id ?? null,
       tokenId: c.token?.id ?? c.tokenId ?? null,
       actorId: actor?.id ?? null,
+      actorType: actor?.type ?? null,
+      actorHasPlayerOwner: Boolean(actor?.hasPlayerOwner),
       name: c.name ?? actor?.name ?? "",
       initiative: c.initiative ?? null,
       hp: {


### PR DESCRIPTION
### Motivation
- Foundry snapshots didn't include actor metadata needed to tell Players from Monsters, which prevented the app from assigning a proper `CreatureType` and finding statblock images. 
- Foundry commonly appends tokens with `#1,#2,...` which broke base-name matching for monster statblocks and the monster list.

### Description
- Add actor metadata to the Foundry snapshot payload by including `actorType` and `actorHasPlayerOwner` in `foundryvtt-bridge/bridge.js` so the app can infer creature type. 
- Implement `_resolve_foundry_creature_type` in `lib/app/app.py` to infer `CreatureType.PLAYER` when `actorHasPlayerOwner` is true or when `actorType` equals `"character"`, and `CreatureType.MONSTER` otherwise. 
- During snapshot sync, set the creature `_type` for matched, existing, and newly-created `I_Creature` objects when the resolved type is available, and enable `death_saves_prompt` for inferred players. 
- Normalize names to handle Foundry’s `#N` suffixes by updating `_normalize_bridge_name`, `populate_monster_list` base-name extraction, and `get_base_name` to strip optional `#` token counters so statblock lookup and monster list deduping work for both `Creature name 1` and `Creature name #1` forms.

### Testing
- No automated tests were run for this change.
- Changes were limited to `foundryvtt-bridge/bridge.js` and `lib/app/app.py` and are intended to be backward compatible when snapshots lack the new metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a8c8d3308327b1a784a26ab0c22d)