### PR TITLE
Avoid caching remote statblock images by default

### DIFF
--- a/lib/app/app.py
+++ b/lib/app/app.py
@@ -1707,13 +1707,14 @@ class Application:
                 pixmap = QPixmap()
                 pixmap.loadFromData(data)
 
-                # Keep local cache in sync (overwrite)
-                try:
-                    os.makedirs(os.path.dirname(image_path), exist_ok=True)
-                    with open(image_path, "wb") as f:
-                        f.write(data)
-                except Exception:
-                    pass
+                # Optional local cache for remote images (disabled by default)
+                if os.getenv("CACHE_REMOTE_IMAGES", "0") == "1":
+                    try:
+                        os.makedirs(os.path.dirname(image_path), exist_ok=True)
+                        with open(image_path, "wb") as f:
+                            f.write(data)
+                    except Exception:
+                        pass
 
             # 2) Fallback to local file if server didn't return anything
             if (pixmap is None or pixmap.isNull()) and os.path.exists(image_path):


### PR DESCRIPTION
### Motivation
- Remote statblock images fetched from the storage API were being saved to the local `images/` folder, causing unwanted local persistence and cache churn.
- The app should display remote images in-memory without writing to disk unless explicitly enabled via a toggle.

### Description
- Changed remote-image handling in `lib/app/app.py` to load bytes into a `QPixmap` via `pixmap.loadFromData(data)` and avoid always writing to disk.
- Added an environment-gated cache: remote images are only written to disk when `CACHE_REMOTE_IMAGES` is set to `1`; the default is `0` (disabled).
- File changed: `lib/app/app.py` (update in `resize_to_fit_screen` where remote data is handled).
- Previously the code always executed `with open(image_path, "wb") as f: f.write(data)`; it now only performs that write when `os.getenv("CACHE_REMOTE_IMAGES", "0") == "1"` so remote images remain in-memory by default.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ab54e02083279bacd5d2a0e91be0)