### PR TITLE
Add local bridge server and SSE-based bridge streaming

### DIFF
--- a/lib/app/bridge_client.py
+++ b/lib/app/bridge_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import requests
 
@@ -56,6 +56,53 @@ class BridgeClient:
             print(f"[Bridge] GET /state failed: {response.status_code} {response.text}")
             return None
         return response.json()
+
+    def stream_state(
+        self,
+        on_snapshot: Callable[[Dict[str, Any]], None],
+        stop_event: "threading.Event",
+    ) -> None:
+        if not self.enabled:
+            print("[Bridge] BRIDGE_TOKEN is not set; skipping stream.")
+            return
+        import threading
+        import time
+        import json as jsonlib
+
+        url = f"{self.base_url}/state/stream"
+        headers = _build_headers(self.token)
+        retry_delay = float(_get_env("BRIDGE_STREAM_RETRY_DELAY", "2"))
+        while not stop_event.is_set():
+            try:
+                with requests.get(
+                    url, headers=headers, timeout=self.timeout_s, stream=True
+                ) as response:
+                    if response.status_code != 200:
+                        print(
+                            f"[Bridge] GET /state/stream failed: {response.status_code} {response.text}"
+                        )
+                        time.sleep(retry_delay)
+                        continue
+                    for line in response.iter_lines(decode_unicode=True):
+                        if stop_event.is_set():
+                            return
+                        if not line:
+                            continue
+                        if line.startswith(":"):
+                            continue
+                        if line.startswith("data:"):
+                            raw = line[len("data:") :].strip()
+                            if not raw:
+                                continue
+                            try:
+                                payload = jsonlib.loads(raw)
+                            except jsonlib.JSONDecodeError:
+                                continue
+                            if isinstance(payload, dict):
+                                on_snapshot(payload)
+            except requests.RequestException as exc:
+                print(f"[Bridge] Stream error: {exc}")
+                time.sleep(retry_delay)
 
     def enqueue_set_hp(
         self,

--- a/lib/app/config.py
+++ b/lib/app/config.py
@@ -29,3 +29,24 @@ def use_storage_api_only() -> bool:
     If set, use the Storage API and skip any local persistence fallbacks.
     """
     return os.getenv("USE_STORAGE_API_ONLY", "0").strip() not in ("", "0", "false", "False")
+
+
+def player_view_enabled() -> bool:
+    """
+    If set, start the Player View HTTP server.
+    """
+    return os.getenv("PLAYER_VIEW_ENABLED", "0").strip() not in ("", "0", "false", "False")
+
+
+def local_bridge_enabled() -> bool:
+    """
+    If set, start a local bridge server inside the app process.
+    """
+    return os.getenv("LOCAL_BRIDGE_ENABLED", "1").strip() not in ("", "0", "false", "False")
+
+
+def bridge_stream_enabled() -> bool:
+    """
+    If set, use the bridge SSE stream instead of polling /state.
+    """
+    return os.getenv("BRIDGE_STREAM_ENABLED", "1").strip() not in ("", "0", "false", "False")

--- a/lib/app/local_bridge_server.py
+++ b/lib/app/local_bridge_server.py
@@ -1,0 +1,44 @@
+import os
+from dataclasses import dataclass
+from threading import Thread
+from typing import Optional
+
+from werkzeug.serving import make_server
+
+from bridge_service.app import create_app
+
+
+def _env(name: str, default: str) -> str:
+    value = os.getenv(name, "").strip()
+    return value or default
+
+
+@dataclass
+class LocalBridgeServer:
+    host: str = "127.0.0.1"
+    port: int = 8787
+    _thread: Optional[Thread] = None
+    _server: Optional[object] = None
+
+    @classmethod
+    def from_env(cls) -> "LocalBridgeServer":
+        host = _env("LOCAL_BRIDGE_HOST", _env("BRIDGE_HOST", "127.0.0.1"))
+        port = int(_env("LOCAL_BRIDGE_PORT", _env("BRIDGE_PORT", "8787")))
+        return cls(host=host, port=port)
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        app = create_app()
+        self._server = make_server(self.host, self.port, app, threaded=True)
+        self._thread = Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        print(f"[Bridge] Local bridge server running on http://{self.host}:{self.port}")
+
+    def stop(self) -> None:
+        if self._server:
+            self._server.shutdown()
+            self._server = None
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+        self._thread = None


### PR DESCRIPTION
### Motivation
- Reduce latency and out-of-sync errors by preferring a persistent connection for snapshot/command sync and provide a single-machine default by running the bridge in-process. 
- Make Player View optional and decouple it from app startup so the app can default to local-first behavior and optional Foundry integration.

### Description
- Add a local in-process bridge server with `LocalBridgeServer` and a `LOCAL_BRIDGE_ENABLED` config flag so the app can start a bridge on `127.0.0.1:8787` by default; the app will auto-populate `BRIDGE_TOKEN`/`BRIDGE_INGEST_SECRET` for local mode when missing (`lib/app/local_bridge_server.py`, `lib/app/app.py`, `lib/app/config.py`). 
- Implement SSE streaming endpoints `GET /state/stream` and `GET /commands/stream` in the bridge service and a version/condition change waiter so streams emit snapshots/commands on change (`bridge_service/app.py`, `bridge_service/command_queue.py`). 
- Wire the desktop client to consume snapshot SSE via `BridgeClient.stream_state` and to optionally use the stream in `Application.start_bridge_stream`; the client still falls back to polling when disabled (`lib/app/bridge_client.py`, `lib/app/app.py`). 
- Update the Foundry module to support an EventSource command stream with a `useCommandStream` module setting and a polling fallback, and add condition detection improvements (`foundryvtt-bridge/bridge.js`). 
- Make the Player View optional via `PLAYER_VIEW_ENABLED`, hide the toggle in the UI when disabled, and ensure clean shutdown of the local bridge and bridge stream when the UI closes (`lib/ui/ui.py`). 
- Update documentation to describe the new flags and local single-machine mode and add stream keepalive config (`README.md`).

### Testing
- No automated tests were executed as part of this change; the patch was applied and compiled statically in this environment but no unit/integration test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bed0acdc8327a6c418cb798d3ea5)