### PR TITLE
Fix command deduplication and GM-only sync to prevent duplicate execution

### DIFF
--- a/lib/app/app.py
+++ b/lib/app/app.py
@@ -240,6 +240,26 @@ class Application:
                 labels = [effect.get("label") for effect in effects if effect.get("label")]
                 creature.conditions = labels
 
+            # Sync HP from Foundry snapshot (covers player-initiated HP changes)
+            hp_data = combatant.get("hp", {})
+            if isinstance(hp_data, dict):
+                hp_value = hp_data.get("value")
+                hp_max = hp_data.get("max")
+                if hp_value is not None:
+                    try:
+                        new_hp = int(hp_value)
+                        if new_hp != getattr(creature, "curr_hp", None):
+                            creature.curr_hp = new_hp
+                    except (TypeError, ValueError):
+                        pass
+                if hp_max is not None:
+                    try:
+                        new_max = int(hp_max)
+                        if new_max != getattr(creature, "max_hp", None):
+                            creature.max_hp = new_max
+                    except (TypeError, ValueError):
+                        pass
+
             ac_value = self._extract_combatant_ac(combatant)
             if ac_value is not None:
                 try:


### PR DESCRIPTION
## Summary
This PR fixes critical issues with command processing and synchronization in the Foundry VTT bridge:

1. **Command Deduplication**: Implements tracking of processed command IDs to prevent duplicate execution when ACK failures occur or network is flaky
2. **GM-Only Sync**: Restricts snapshot generation and command processing to GM clients only, preventing permission errors and duplicate changes from player clients
3. **Always ACK Commands**: Changes behavior to ACK all commands (success or failure) to prevent indefinite re-polling of failed commands
4. **HP Sync**: Adds HP synchronization from Foundry snapshots to handle player-initiated HP changes

## Key Changes

**bridge.js:**
- Added `processedCommandIds` Set to track executed command IDs with a max size cap (200) to prevent unbounded memory growth
- Modified `handleCommand()` to:
  - Skip duplicate commands that have already been processed
  - Always ACK commands regardless of success/failure (previously only successful commands were ACKed)
  - ACK invalid commands to prevent queue blocking
- Added GM-only guard in `Hooks.once("ready")` to disable bridge sync for non-GM clients
- Added `game.user?.isGM` checks to all snapshot-triggering hooks to prevent player clients from generating snapshots
- Prevents permission errors and duplicate state changes from multiple clients attempting modifications

**app.py:**
- Added HP value and max HP synchronization from Foundry combatant snapshots
- Handles both current HP and max HP updates with proper type conversion and error handling
- Covers player-initiated HP changes that may occur outside of combat actions

## Implementation Details
- Command deduplication uses a Set with FIFO eviction when size exceeds MAX_PROCESSED_IDS
- GM check uses optional chaining (`game.user?.isGM`) for safety
- HP sync includes defensive type checking and exception handling for malformed data
- All changes maintain backward compatibility with existing command/snapshot flow

https://claude.ai/code/session_01GkPk2EJjAqw2n4mKMYXDFZ