### PR TITLE
Use repo .env STORAGE_API_BASE for bulk import and add --dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,34 @@ STORAGE_API_KEY=your_api_key_if_required
 
 Leave `USE_STORAGE_API_ONLY` unset (or set it to `0`) to kep using the built-in local JSOn files. If you enable `USE_STORAGE_API_ONLY` without providing `STORAGE_API_BASE`, the app will start but show a warning explaining how the to fix the configuration so you are not blocked while the Storage service is offline.
 
+
+## One-time bulk spell import script
+If you want to paste many D&D Beyond spells at once, use the helper script:
+
+```bash
+python import_spells_bulk.py /path/to/spells.txt
+```
+
+By default, this will upload to the Storage API using `STORAGE_API_BASE` from your repo `.env`.
+It also skips `Legacy` entries unless you include `--include-legacy`.
+
+Use `--dry-run` if you want parse + summary only:
+
+```bash
+python import_spells_bulk.py /path/to/spells.txt --dry-run
+```
+
+```bash
+# include legacy blocks and override API URL explicitly
+python import_spells_bulk.py /path/to/spells.txt --include-legacy --base-url https://your-storage-api.example.com
+```
+
+You can also paste directly from clipboard content via stdin:
+
+```bash
+pbpaste | python import_spells_bulk.py --base-url https://your-storage-api.example.com
+```
+
 ## Player View (Foundry-friendly)
 When enabled, the app launches a lightweight Player View web page that can be embedded in Foundry via Inline Webviewer. The page is designed to be iframe-friendly and shows only player-safe combat data.
 

--- a/import_spells_bulk.py
+++ b/import_spells_bulk.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from dotenv import find_dotenv, load_dotenv
+
+from app.bulk_spell_import import dedupe_prefer_non_legacy, parse_bulk_spells
+from app.storage_api import StorageAPI
+
+
+def _read_input(path: str | None) -> str:
+    if path:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    return sys.stdin.read()
+
+
+def main() -> int:
+    # Mirror app behavior by loading .env in the current repo/project directory.
+    load_dotenv(find_dotenv(usecwd=True), override=False)
+
+    parser = argparse.ArgumentParser(
+        description="One-time bulk spell parser for D&D Beyond pasted blocks."
+    )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        help="Path to text file containing multiple pasted spells. Reads stdin if omitted.",
+    )
+    parser.add_argument(
+        "--include-legacy",
+        action="store_true",
+        help="Include blocks marked Legacy (default skips them).",
+    )
+    parser.add_argument(
+        "--no-dedupe",
+        action="store_true",
+        help="Do not dedupe by key (default dedupes and prefers non-legacy).",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Deprecated compatibility flag. Upload is now the default behavior.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse and report only. Do not upload to the Storage API.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("STORAGE_API_BASE", ""),
+        help="Storage API base URL. Defaults to STORAGE_API_BASE env var.",
+    )
+    args = parser.parse_args()
+
+    raw = _read_input(args.input)
+    spells = parse_bulk_spells(raw, include_legacy=args.include_legacy)
+    if not args.no_dedupe:
+        spells = dedupe_prefer_non_legacy(spells)
+
+    if not spells:
+        print("No parseable spells found.")
+        return 1
+
+    print(f"Parsed {len(spells)} spells")
+    warning_count = 0
+    for spell in spells:
+        if spell.warnings:
+            warning_count += 1
+            print(f"- {spell.name} ({spell.key}) warnings: {', '.join(spell.warnings)}")
+        else:
+            print(f"- {spell.name} ({spell.key})")
+
+    if warning_count:
+        print(f"\n{warning_count} spells had parser warnings.")
+
+    if args.dry_run:
+        print("\nDry-run only. Re-run without --dry-run to PUT to Storage API.")
+        return 0
+
+    if not args.base_url:
+        print(
+            "No base URL set. Use --base-url or set STORAGE_API_BASE in your repo .env.",
+            file=sys.stderr,
+        )
+        return 2
+
+    api = StorageAPI(args.base_url)
+    uploaded = 0
+    failed = 0
+
+    for spell in spells:
+        try:
+            api.save_spell(spell.key, spell.data)
+            uploaded += 1
+        except Exception as exc:
+            failed += 1
+            print(f"Failed upload {spell.key}: {exc}", file=sys.stderr)
+
+    print(f"\nUpload complete: {uploaded} succeeded, {failed} failed.")
+    return 0 if failed == 0 else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/app/bulk_spell_import.py
+++ b/lib/app/bulk_spell_import.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+from app.spell_parser import parse_spell, spell_key, validate_spell
+
+
+_LEVEL_TOKEN_RE = re.compile(r"^(?:cantrip|[1-9](?:st|nd|rd|th))$", re.IGNORECASE)
+_BLOCK_BREAK_MARKERS = {"view details page", "tags:", "available for:"}
+
+
+@dataclass
+class ParsedSpellBlock:
+    name: str
+    key: str
+    data: dict
+    warnings: list[str]
+    is_legacy: bool
+
+
+
+def _normalize_lines(text: str) -> list[str]:
+    lines = [line.strip() for line in text.splitlines()]
+    return [line for line in lines if line]
+
+
+
+def _looks_like_spell_name(line: str) -> bool:
+    if not line:
+        return False
+    lower = line.lower()
+    if lower in {
+        "level",
+        "casting time",
+        "range/area",
+        "components",
+        "duration",
+        "school",
+        "attack/save",
+        "damage/effect",
+    }:
+        return False
+    return not line.endswith(":")
+
+
+
+def _find_spell_starts(lines: list[str]) -> list[int]:
+    starts: list[int] = []
+    for idx in range(len(lines) - 1):
+        if _LEVEL_TOKEN_RE.match(lines[idx]) and _looks_like_spell_name(lines[idx + 1]):
+            starts.append(idx)
+    return starts
+
+
+
+def _cut_block_metadata(block_lines: list[str]) -> list[str]:
+    for idx, line in enumerate(block_lines):
+        if line.strip().lower() in _BLOCK_BREAK_MARKERS:
+            return block_lines[:idx]
+    return block_lines
+
+
+
+def _extract_parseable_spell_text(segment: list[str]) -> tuple[str, bool] | None:
+    if len(segment) < 3:
+        return None
+
+    name = segment[1].strip()
+    is_legacy = any(line.strip().lower() == "legacy" for line in segment[:8])
+
+    level_idx = -1
+    for idx, line in enumerate(segment):
+        if line.strip().lower() == "level":
+            level_idx = idx
+            break
+
+    if level_idx < 0:
+        return None
+
+    block = _cut_block_metadata(segment[level_idx:])
+    parse_text = "\n".join([name] + block)
+    return parse_text, is_legacy
+
+
+
+def parse_bulk_spells(text: str, *, include_legacy: bool = False) -> list[ParsedSpellBlock]:
+    lines = _normalize_lines(text)
+    if not lines:
+        return []
+
+    starts = _find_spell_starts(lines)
+    if not starts:
+        return []
+
+    parsed: list[ParsedSpellBlock] = []
+    boundaries = starts + [len(lines)]
+
+    for start, end in zip(boundaries, boundaries[1:]):
+        segment = lines[start:end]
+        built = _extract_parseable_spell_text(segment)
+        if built is None:
+            continue
+
+        parse_text, is_legacy = built
+        if is_legacy and not include_legacy:
+            continue
+
+        try:
+            data = parse_spell(parse_text)
+        except Exception:
+            continue
+
+        name = data.get("name", "").strip()
+        if not name:
+            continue
+
+        parsed.append(
+            ParsedSpellBlock(
+                name=name,
+                key=spell_key(name),
+                data=data,
+                warnings=validate_spell(data),
+                is_legacy=is_legacy,
+            )
+        )
+
+    return parsed
+
+
+
+def dedupe_prefer_non_legacy(spells: Iterable[ParsedSpellBlock]) -> list[ParsedSpellBlock]:
+    by_key: dict[str, ParsedSpellBlock] = {}
+    for spell in spells:
+        existing = by_key.get(spell.key)
+        if existing is None:
+            by_key[spell.key] = spell
+            continue
+        if existing.is_legacy and not spell.is_legacy:
+            by_key[spell.key] = spell
+    return list(by_key.values())

--- a/tests/test_bulk_spell_import.py
+++ b/tests/test_bulk_spell_import.py
@@ -1,0 +1,85 @@
+from app.bulk_spell_import import dedupe_prefer_non_legacy, parse_bulk_spells
+
+
+_SAMPLE = """
+2nd
+Calm Emotions
+Concentration
+Enchantment • V, S
+1 Action
+1 Minute
+60 ft.
+(20 ft. )
+CHA Save
+Charmed (...)
+Level
+2nd
+Casting Time
+1 Action
+Range/Area
+60 ft. (20 ft. )
+Components
+V, S
+Duration
+Concentration 1 Minute
+School
+Enchantment
+Attack/Save
+CHA Save
+Damage/Effect
+ Charmed (...)
+Each Humanoid in a 20-foot-radius Sphere centered on a point you choose within range must succeed on a Charisma saving throw.
+View Details Page
+Tags:
+Social
+1st
+Charm Person
+Legacy
+Enchantment • V, S
+1 Action
+1 Hour
+30 ft.
+WIS Save
+Charmed
+Level
+1st
+Casting Time
+1 Action
+Range/Area
+30 ft.
+Components
+V, S
+Duration
+1 Hour
+School
+Enchantment
+Attack/Save
+WIS Save
+Damage/Effect
+ Charmed
+You attempt to charm a humanoid you can see within range.
+View Details Page
+Tags:
+Control
+"""
+
+
+def test_parse_bulk_spells_skips_legacy_by_default():
+    spells = parse_bulk_spells(_SAMPLE)
+    assert [s.name for s in spells] == ["Calm Emotions"]
+    assert spells[0].data["concentration"] is True
+
+
+def test_parse_bulk_spells_include_legacy():
+    spells = parse_bulk_spells(_SAMPLE, include_legacy=True)
+    names = [s.name for s in spells]
+    assert "Calm Emotions" in names
+    assert "Charm Person" in names
+
+
+def test_dedupe_prefers_non_legacy():
+    spells = parse_bulk_spells(_SAMPLE, include_legacy=True)
+    # manufacture duplicate key by appending a second legacy/non-legacy pair
+    keep = dedupe_prefer_non_legacy(spells + spells)
+    keys = [s.key for s in keep]
+    assert len(keys) == len(set(keys))


### PR DESCRIPTION
### Motivation
- Make the one-time bulk spell import CLI use the same repo-level configuration as the main app by default so uploads target the developer-configured `STORAGE_API_BASE` in the repo `.env`.
- Provide a safe non-destructive inspection mode so users can parse and review spells without attempting uploads.
- Keep backward compatibility for prior invocations while surfacing a clearer default behavior.

### Description
- Load the repo `.env` automatically at startup using `find_dotenv(usecwd=True)` + `load_dotenv(...)` and make `STORAGE_API_BASE` the default for the `--base-url` option in `import_spells_bulk.py`.
- Add a `--dry-run` flag that parses and prints a summary without performing any uploads, and make upload the default path when `--dry-run` is not provided while retaining `--upload` as a deprecated compatibility flag.
- Validate presence of a base URL (from `--base-url` or repo `.env`) before attempting uploads and print a clear error if missing.
- Update `README.md` usage examples to document the `.env` default and the new `--dry-run` workflow.

### Testing
- Ran `pytest -q tests/test_bulk_spell_import.py`, which passed: `3 passed`.
- Verified CLI help with `python import_spells_bulk.py --help` and confirmed options and help text render as expected.
- Performed a sample dry-run with `python import_spells_bulk.py /tmp/spells.txt --dry-run` and confirmed parsing output without attempting uploads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f0d8b0108327bee6a5abb9883cb3)