### PR TITLE
Add tooltip styling for statblock conditions and spells

### DIFF
--- a/lib/ui/theme.py
+++ b/lib/ui/theme.py
@@ -162,4 +162,12 @@ def get_stylesheet() -> str:
     QDialogButtonBox > QPushButton {{
         min-width: 70px;
     }}
+
+    /* ── Tooltips (statblock condition/spell hover) ───── */
+    QToolTip {{
+        background-color: #FEF5E5;
+        color: #1a1a1a;
+        border: 1px solid #C9801A;
+        padding: 4px;
+    }}
     """


### PR DESCRIPTION
## Summary
Added custom styling for tooltips that appear when hovering over statblock conditions and spells, improving the visual consistency and readability of tooltip elements throughout the UI.

## Key Changes
- Added `QToolTip` stylesheet rules with a warm, light background color (#FEF5E5) that complements the existing UI theme
- Applied dark text color (#1a1a1a) for optimal contrast and readability
- Added a subtle border (1px solid #C9801A) to define tooltip boundaries
- Set padding to 4px for appropriate spacing around tooltip content

## Implementation Details
The tooltip styling uses a warm beige background that aligns with the application's color palette, with a golden-brown border that provides visual definition without being obtrusive. This creates a cohesive appearance for hover information across statblock-related UI elements.

https://claude.ai/code/session_01BnNyvAxp7JqGJNiBK6V6xD